### PR TITLE
Fix customize multimedia page failing, resolves #14

### DIFF
--- a/app/customize.py
+++ b/app/customize.py
@@ -441,7 +441,7 @@ def multimedia(aa):
                            tc=data.Touch_store.query,
                            sl=data.Slides.query,
                            dc=data.Display_store.query,
-                           fs=int(ex_functions.getFolderSize(dire)),
+                           fs=int(ex_functions.getFolderSize(dire, True)),
                            nofl=nofl, sfl=sfl,
                            vtrue=data.Vid.query.first().enable,
                            strue=data.Slides_c.query.first().status)

--- a/app/ex_functions.py
+++ b/app/ex_functions.py
@@ -48,8 +48,10 @@ def mse():
     db.session.commit()
 
 
-def getFolderSize(folder):
+def getFolderSize(folder, safely=False):
     # -- get a folder size
+    if safely and not os.path.isdir(folder):
+        os.makedirs(folder)
     total_size = os.path.getsize(folder)
     for item in os.listdir(folder):
         itempath = os.path.join(folder, item)
@@ -57,7 +59,7 @@ def getFolderSize(folder):
             total_size += os.path.getsize(itempath)
         elif os.path.isdir(itempath):
             total_size += getFolderSize(itempath)
-    return str(total_size / 1024 / 1024)
+    return int(float(total_size / 1024 / 1024))
 
 
 def r_path(relative_path):


### PR DESCRIPTION
- Add get folder size safely flag
- Enable flag in multimedia endpoint
- Remove py2 installation from `README.md`

<b> `Customize.multimedia` before : </b>
![multimedia_before](https://user-images.githubusercontent.com/26286907/69904078-189f1380-13dd-11ea-9dbe-19c3ab560d7a.png)

<b> `Customize.multimedia` after : </b>
![multimedia_after](https://user-images.githubusercontent.com/26286907/69904081-1e94f480-13dd-11ea-8f9e-14f181834f32.png)

