### PR TITLE
Major refactoring and renaming

### DIFF
--- a/app/administrate.py
+++ b/app/administrate.py
@@ -3,16 +3,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from flask import url_for, flash, request, render_template
-from flask import redirect, Markup, session, send_file, Blueprint
-from flask_login import current_user, login_required
-from flask_login import login_user, logout_user
+import csv
+from flask import url_for, flash, request, render_template, redirect, session, send_file, Blueprint
+from flask_login import current_user, login_required, logout_user
 from datetime import datetime
+
 import app.data as data
 from app.database import db, login_manager
 import app.forms as forms
-import csv
 from app.ex_functions import r_path
+from app.helpers import reject_not_god, reject_not_admin
 
 
 administrate = Blueprint('administrate', __name__)
@@ -20,13 +20,13 @@ administrate = Blueprint('administrate', __name__)
 
 @login_manager.user_loader
 def load_user(user_id):
-    """ getting the current user """
+    ''' getting the current user '''
     return data.User.query.get(int(user_id))
 
 
 @administrate.before_request
 def update_last_seen():
-    """ adding the last time user logged in """
+    ''' adding the last time user logged in '''
     if current_user.is_authenticated:
         current_user.last_seen = datetime.utcnow()
         db.session.add(current_user)
@@ -35,50 +35,37 @@ def update_last_seen():
 
 @login_manager.unauthorized_handler
 def unauthorized_callback():
-    """ if user not logged in """ 
+    ''' if user not logged in '''
     session['next_url'] = request.path
-    flash(
-        "Error: login is required to access the page",
-        'danger')
-    return redirect(url_for("core.root", n='b'))
+    flash('Error: login is required to access the page', 'danger')
+    return redirect(url_for('core.root', n='b'))
 
 
 @administrate.route('/admin_u', methods=['GET', 'POST'])
 @login_required
+@reject_not_god
 def admin_u():
-    """ updating admin password """
-    if current_user.id != 1:
-        flash(
-            'Error: only main Admin account can access the page',
-            'danger')
-        return redirect(url_for('core.root'))
+    ''' updating main admin account password '''
     form = forms.U_admin(session.get('lang'))
     admin = data.User.query.filter_by(id=1).first()
     if form.validate_on_submit():
         admin.password = form.password.data
         db.session.commit()
-        flash(
-            'Notice: admin password has been updated.',
-            'info')
+        flash('Notice: admin password has been updated.', 'info')
         return redirect(url_for('administrate.logout'))
     return render_template('admin_u.html',
                            navbar='#snb3',
-                           ptitle="Updating Admin Password",
+                           page_title='Updating Admin Password',
                            form=form)
 
 
 @administrate.route('/csvd/<t_name>', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def csvd(t_name):
-    """ to export tables to .csvd file """
-    if current_user.role_id != 1:
-        flash(
-            'Error: only administrator can access the page',
-            'danger')
-        return redirect(url_for('core.root'))
+    ''' to export tables to .csvd file '''
     form = forms.CSV(session.get('lang'))
-    t_ids = ['User', 'Office', 'Task', 'Serial',
-                     'Waiting', 'Roles']
+    t_ids = ['User', 'Office', 'Task', 'Serial', 'Waiting', 'Roles']
     if t_name in t_ids:
         t_name = eval('data.' + t_name)
         fn = 'csvd.csv'
@@ -103,20 +90,14 @@ def csvd(t_name):
     if form.validate_on_submit():
         return redirect(url_for('administrate.csvd',
                                 t_name=form.table.data))
-    return render_template('csvs.html',
-                           navbar='#snb3',
-                           ptitle='Export CSV',
-                           form=form)
+    return render_template('csvs.html', navbar='#snb3', page_title='Export CSV', form=form)
 
 
 @administrate.route('/users', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def users():
-    """ to list all users """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('root'))
+    ''' to list all users '''
     page = request.args.get('page', 1, type=int)
     if page > int(data.User.query.count() / 10) + 1:
         flash('Error: wrong entry, something went wrong',
@@ -125,7 +106,7 @@ def users():
     pagination = data.User.query.paginate(page, per_page=10,
                                           error_out=False)
     return render_template('users.html',
-                           ptitle='All users',
+                           page_title='All users',
                            navbar='#snb3',
                            len=len,
                            offices=data.Office.query,
@@ -138,25 +119,22 @@ def users():
 @administrate.route('/operators/<int:t_id>', methods=['GET', 'POST'])
 @login_required
 def operators(t_id):
-    """ to list operators of an office """
+    ''' to list operators of an office '''
     office = data.Office.query.filter_by(id=t_id).first()
     if office is None:
-        flash('Error: wrong entry, something went wrong',
-              "danger")
+        flash('Error: wrong entry, something went wrong', 'danger')
         return redirect(url_for('root'))
-    if current_user.role_id == 3 and data.Operators.query.filter_by(id=current_user.id).first() is None :
-        flash('Error: only administrator can access the page',
-              "danger")
+    if current_user.role_id == 3 and\
+       data.Operators.query.filter_by(id=current_user.id).first() is None:
+        flash('Error: only administrator can access the page', 'danger')
         return redirect(url_for('root'))
     page = request.args.get('page', 1, type=int)
     if page > int(data.Operators.query.count() / 10) + 1:
-        flash('Error: wrong entry, something went wrong',
-              'danger')
+        flash('Error: wrong entry, something went wrong', 'danger')
         return redirect(url_for('manage.office', o_id=t_id))
-    pagination = data.Operators.query.filter_by(office_id=t_id).paginate(page, per_page=10,
-                                          error_out=False)
+    pagination = data.Operators.query.filter_by(office_id=t_id).paginate(page, per_page=10, error_out=False)
     return render_template('operators.html',
-                           ptitle=str(office.name) + ' operators',
+                           page_title=str(office.name) + ' operators',
                            len=len,
                            offices=data.Office.query,
                            pagination=pagination,
@@ -165,28 +143,23 @@ def operators(t_id):
                            users=data.User.query,
                            tasks=data.Task.query,
                            operators=data.Operators.query,
-                           navbar="#snb1",
-                           dropdown="#dropdown-lvl" + str(t_id),
-                           hash="#to" + str(t_id))
+                           navbar='#snb1',
+                           dropdown='#dropdown-lvl' + str(t_id),
+                           hash='#to' + str(t_id))
 
 
 @administrate.route('/user_a', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def user_a():
-    """ to add a user """
-    if current_user.role_id != 1:
-        flash('Error: wrong entry, something went wrong',
-              "danger")
-        return redirect(url_for('core.root'))
+    ''' to add a user '''
     form = forms.User_a(session.get('lang'))
     if form.validate_on_submit():
         if data.User.query.filter_by(name=form.name.data).first() is not None:
-            flash("Error: user name already exists, choose another name",
-                  "danger")
+            flash('Error: user name already exists, choose another name',
+                  'danger')
             return redirect(url_for('administrate.user_a'))
-        db.session.add(data.User(form.name.data,
-                                 form.password.data,
-                                 form.role.data))
+        db.session.add(data.User(form.name.data, form.password.data, form.role.data))
         db.session.commit()
         # Fix: multiple operators for office
         # adding user to Operators list
@@ -196,33 +169,24 @@ def user_a():
                 form.offices.data
             ))
             db.session.commit()
-        flash("Notice: user has been added .",
-              "info")
+        flash('Notice: user has been added .', 'info')
         return redirect(url_for('administrate.users'))
-    return render_template('user_add.html',
-                           form=form, navbar='#snb3',
-                           ptitle='Add user')
+    return render_template('user_add.html', form=form, navbar='#snb3', page_title='Add user')
 
 
 @administrate.route('/user_u/<int:u_id>', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def user_u(u_id):
-    """ to update user """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
+    ''' to update user '''
     form = forms.User_a(session.get('lang'))
     u = data.User.query.filter_by(id=u_id).first()
     if u is None:
-        flash(
-            "Error: user selected does not exist, something wrong !",
-            "danger")
-        return redirect(url_for("core.root"))
+        flash('Error: user selected does not exist, something wrong !', 'danger')
+        return redirect(url_for('core.root'))
     if u.id == 1:
-        flash("Error: main admin account cannot be updated .",
-              "danger")
-        return redirect(url_for("administrate.users"))
+        flash('Error: main admin account cannot be updated .', 'danger')
+        return redirect(url_for('administrate.users'))
     if form.validate_on_submit():
         u.name = form.name.data
         u.password = form.password.data
@@ -239,8 +203,7 @@ def user_u(u_id):
             if toRemove is not None:
                 db.session.delete(toRemove)
         db.session.commit()
-        flash("Notice: user is updated . ",
-              "info")
+        flash('Notice: user is updated . ', 'info')
         return redirect(url_for('administrate.users'))
     if not form.errors:
         form.name.data = u.name
@@ -251,45 +214,39 @@ def user_u(u_id):
             form.offices.data = data.Operators.query.filter_by(id=u.id).first().office_id
     return render_template('user_add.html',
                            form=form, navbar='#snb3',
-                           ptitle='Update user : ' + u.name,
+                           page_title='Update user : ' + u.name,
                            u=u, update=True)
 
 
 @administrate.route('/user_d/<int:u_id>')
 @login_required
+@reject_not_admin
 def user_d(u_id):
-    """ to delete user """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
+    ''' to delete user '''
     u = data.User.query.filter_by(id=u_id).first()
     if u is None:
-        flash("Error: user selected does not exist, something wrong !",
-              "danger")
-        return redirect(url_for("core.root"))
+        flash('Error: user selected does not exist, something wrong !',
+              'danger')
+        return redirect(url_for('core.root'))
     if u.id == 1:
-        flash("Error: main admin account cannot be updated .",
-              "danger")
-        return redirect(url_for("administrate.users"))
+        flash('Error: main admin account cannot be updated .',
+              'danger')
+        return redirect(url_for('administrate.users'))
     # delete from operators if user is operator
     if u.role_id == 3:
         db.session.delete(data.Operators.query.filter_by(id=u.id).first())
     db.session.delete(u)
     db.session.commit()
-    flash("Notice: user is deleted .",
-          "info")
+    flash('Notice: user is deleted .',
+          'info')
     return redirect(url_for('administrate.users'))
 
 
 @administrate.route('/user_da')
 @login_required
+@reject_not_admin
 def user_da():
-    """ to delete all users """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
+    ''' to delete all users '''
     for u in data.User.query:
         # Fix: multiple operators for office
         # ofc = data.Office.query.filter_by(operator_id=u.id).first()
@@ -300,20 +257,17 @@ def user_da():
         if u.id != 1:
             db.session.delete(u)
     db.session.commit()
-    flash("Notice: all unassigned users got deleted.",
-          "info")
+    flash('Notice: all unassigned users got deleted.', 'info')
     return redirect(url_for('administrate.users'))
 
 
 @administrate.route('/logout')
 @login_required
 def logout():
-    """ to logout the current user """
+    ''' to logout the current user '''
     if not current_user.is_authenticated:
-        flash(
-            "Error: you cannot logout without a login !"
-            , "danger")
-        return redirect(url_for("core.root"))
+        flash('Error: you cannot logout without a login !', 'danger')
+        return redirect(url_for('core.root'))
     logout_user()
-    flash("Notice: logout is done.", "info")
-    return redirect(url_for("core.root"))
+    flash('Notice: logout is done.', 'info')
+    return redirect(url_for('core.root'))

--- a/app/customize.py
+++ b/app/customize.py
@@ -18,6 +18,7 @@ from app.database import db, files
 from app.printer import listp
 from app.ex_functions import r_path
 from app.constants import SUPPORTED_MEDIA_FILES
+from app.helpers import reject_not_admin
 
 
 cust_app = Blueprint('cust_app', __name__)
@@ -25,15 +26,11 @@ cust_app = Blueprint('cust_app', __name__)
 
 @cust_app.route('/customize')
 @login_required
+@reject_not_admin
 def customize():
     """ view of main customize screen """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     return render_template("customize.html",
-                           ptitle="Customization",
+                           page_title="Customization",
                            navbar="#snb2",
                            vtrue=data.Vid.query.first().enable,
                            strue=data.Slides_c.query.first().status)
@@ -41,6 +38,7 @@ def customize():
 
 @cust_app.route('/ticket', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def ticket():
     """ view of ticket customization """
     if os.name == 'nt':
@@ -48,11 +46,6 @@ def ticket():
         lll = listpp()
     else:
         lll = listp()
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              'danger')
-        return redirect(url_for('core.root'))
     form = forms.Printer_f(lll, session.get('lang'))
     tc = data.Touch_store.query.first()
     pr = data.Printer.query.first()
@@ -96,7 +89,7 @@ def ticket():
         form.langu.data = pr.langu
         form.value.data = pr.value
     return render_template('ticket.html', navbar='#snb2',
-                           ptitle='Tickets',
+                           page_title='Tickets',
                            vtrue=data.Vid.query.first().enable,
                            strue=data.Slides_c.query.first().status,
                            form=form, hash='#da7')
@@ -104,13 +97,9 @@ def ticket():
 
 @cust_app.route('/video', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def video():
     """ view of video customization for display """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              'danger')
-        return redirect(url_for('core.root'))
     if data.Slides_c.query.first().status == 1:
         flash('Error: must disable slide-show before using video',
               'danger')
@@ -144,7 +133,7 @@ def video():
         form.controls.data = vdb.controls
         form.mute.data = vdb.mute
     return render_template('video.html',
-                           ptitle='Video settings',
+                           page_title='Video settings',
                            navbar='#snb2',
                            hash='#da5',
                            form=form,
@@ -154,13 +143,9 @@ def video():
 
 @cust_app.route('/slideshow', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def slideshow():
     """ view of slide-show customization for display """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     if data.Vid.query.first().enable == 1:
         flash('Error: must disable video before using slide-show',
               'danger')
@@ -180,7 +165,7 @@ def slideshow():
                            pagination=pagination,
                            sm=data.Slides.query.filter(data.Slides.
                                                        ikey != 0).count(),
-                           ptitle="All slides",
+                           page_title="All slides",
                            hash="#ss1",
                            dropdown="#dropdown-lvl3",
                            vtrue=data.Vid.query.first().enable,
@@ -189,13 +174,9 @@ def slideshow():
 
 @cust_app.route('/slide_a', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def slide_a():
     """ adding a slide """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     if data.Vid.query.first().enable == 1:
         flash('Error: must disable video before using slide-show',
               'danger')
@@ -208,7 +189,7 @@ def slide_a():
             bb = data.Media.query.filter_by(id=form.background.data).first()
             if bb is None:
                 flash('Error: wrong entry, something went wrong',
-                "danger")
+                'danger')
                 return redirect(url_for("cust_app.slide_a"))
             bb = bb.name
         ss = data.Slides()
@@ -226,10 +207,10 @@ def slide_a():
         ss.ikey = form.background.data
         db.session.add(ss)
         db.session.commit()
-        flash("Notice: templates been updated.", "info")
+        flash("Notice: templates been updated.", 'info')
         return redirect(url_for("cust_app.slideshow"))
     return render_template("slide_add.html",
-                           ptitle="Add Slide ",
+                           page_title="Add Slide ",
                            form=form, navbar="#snb2",
                            hash=1,
                            dropdown='#dropdown-lvl3',
@@ -239,13 +220,9 @@ def slide_a():
 
 @cust_app.route('/slide_c', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def slide_c():
     """ updating a slide """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     if data.Vid.query.first().enable == 1:
         flash('Error: must disable video before using slide-show',
               'danger')
@@ -260,7 +237,7 @@ def slide_c():
         db.session.add(sc)
         db.session.commit()
         flash("Notice: slide settings is done.",
-        "info")
+        'info')
         return redirect(url_for("cust_app.slide_c"))
     if not form.errors:
         form.rotation.data = sc.rotation
@@ -270,7 +247,7 @@ def slide_c():
     return render_template("slide_settings.html",
                            form=form, navbar="#snb2",
                            hash="#ss2",
-                           ptitle="Slideshow settings",
+                           page_title="Slideshow settings",
                            dropdown="#dropdown-lvl3",
                            vtrue=data.Vid.query.first().enable,
                            strue=data.Slides_c.query.first().status)
@@ -278,16 +255,12 @@ def slide_c():
 
 @cust_app.route('/slide_r/<int:f_id>')
 @login_required
+@reject_not_admin
 def slide_r(f_id):
     """ removing a slide """
-    ex_functions.mse()
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     if data.Slides.query.count() <= 0:
         flash("Error: there is no slides to be removed ",
-        "danger")
+        'danger')
         return redirect(url_for('cust_app.slideshow'))
     if data.Vid.query.first().enable == 1:
         flash('Error: must disable video before using slide-show',
@@ -298,32 +271,28 @@ def slide_r(f_id):
             if a is not None:
                 db.session.delete(a)
         db.session.commit()
-        flash("Notice: All slides removed.", "info")
+        flash("Notice: All slides removed.", 'info')
         return redirect(url_for('cust_app.slideshow'))
     mf = data.Slides.query.filter_by(id=f_id).first()
     if mf is not None:
         db.session.delete(mf)
         db.session.commit()
-        flash("Notice: All slides removed.", "info")
+        flash("Notice: All slides removed.", 'info')
         return redirect(url_for('cust_app.slideshow'))
     else:
-        flash("Error: there is no slides to be removed ", "danger")
+        flash("Error: there is no slides to be removed ", 'danger')
         return redirect(url_for('core.root'))
 
 
 @cust_app.route('/multimedia/<int:aa>', methods=['POST', 'GET'])
 @login_required
+@reject_not_admin
 def multimedia(aa):
     """ uploading multimedia files """
     # Number of files limit
     nofl = 300
     # size folder limit in MB
     sfl = 2000 # Fix limited upload folder size
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
-    ex_functions.mse()
     dire = r_path('static/multimedia/')
     pf = data.Media.query.order_by(data.Media.id.desc()).first()
     if pf is not None:
@@ -332,14 +301,14 @@ def multimedia(aa):
         if data.Media.query.count() >= nofl:
             flash(
                 "Error: you have reached the amount limit of multimedia files " + str(nofl),
-                "danger")
+                'danger')
             return redirect(url_for('cust_app.multimedia', aa=1))
         else:
             flash("Notice: if you followed the rules, it should be uploaded ..",
                   "success")
     elif aa != 1:
         flash('Error: wrong entry, something went wrong',
-              "danger")
+              'danger')
         return redirect(url_for("core.root"))
     mmm = data.Media.query
     page = request.args.get('page', 1, type=int)
@@ -424,10 +393,10 @@ def multimedia(aa):
             db.session.commit()
             return redirect(url_for("cust_app.multimedia", aa=1))
         else:
-            flash('Error: wrong entry, something went wrong', "danger")
+            flash('Error: wrong entry, something went wrong', 'danger')
             return redirect(url_for("cust_app.multimedia", aa=1))
     return render_template("multimedia.html",
-                           ptitle="Multimedia",
+                           page_title="Multimedia",
                            navbar="#snb2",
                            form=form,
                            hash="#da1",
@@ -447,16 +416,13 @@ def multimedia(aa):
 
 @cust_app.route('/multi_del/<int:f_id>')
 @login_required
+@reject_not_admin
 def multi_del(f_id):
     """ to delete multimedia file """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     dire = r_path('static/multimedia/')
     if data.Media.query.filter_by(used=False).count() <= 0:
         flash("Error: there is no unused multimedia file to be removed !",
-              "danger")
+              'danger')
         return redirect(url_for('cust_app.multimedia', aa=1))
     if f_id == 00:
         for a in data.Media.query:
@@ -465,37 +431,33 @@ def multi_del(f_id):
                     os.remove(dire + a.name)
                 db.session.delete(a)
         db.session.commit()
-        flash("Notice: multimedia file been removed.", "info")
+        flash("Notice: multimedia file been removed.", 'info')
         return redirect(url_for('cust_app.multimedia', aa=1))
     mf = data.Media.query.filter_by(id=f_id).first()
     if mf is not None:
         if mf.used:
             flash("Error: there is no unused multimedia file to be removed !",
-                  "danger")
+                  'danger')
             return redirect(url_for('cust_app.multimedia', aa=1))
         if os.path.exists(dire + mf.name):
             os.remove(dire + mf.name)
         db.session.delete(mf)
         db.session.commit()
-        flash("Notice: multimedia file been removed.", "info")
+        flash("Notice: multimedia file been removed.", 'info')
         return redirect(url_for('cust_app.multimedia', aa=1))
     else:
-        flash("Error: there is no unused multimedia file to be removed !", "danger")
+        flash("Error: there is no unused multimedia file to be removed !", 'danger')
         return redirect(url_for('core.root'))
 
 
 @cust_app.route('/displayscreen_c/<int:stab>', methods=['POST', 'GET'])
 @login_required
+@reject_not_admin
 def displayscreen_c(stab):
     """ view for display screen customization """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
-    ex_functions.mse()
     form = forms.Display_c(session.get('lang'))
     if stab not in range(1, 9):
-        flash('Error: wrong entry, something went wrong', "danger")
+        flash('Error: wrong entry, something went wrong', 'danger')
         return redirect(url_for('core.root'))
     touch_s = data.Display_store.query.filter_by(id=0).first()
     if form.validate_on_submit():
@@ -547,7 +509,7 @@ def displayscreen_c(stab):
             touch_s.akey = form.naudio.data
         db.session.add(touch_s)
         db.session.commit()
-        flash("Notice: Display customization has been updated. ..", "info")
+        flash("Notice: Display customization has been updated. ..", 'info')
         return redirect(url_for("cust_app.displayscreen_c", stab=1))
     if not form.errors:
         form.display.data = touch_s.tmp
@@ -585,7 +547,7 @@ def displayscreen_c(stab):
             form.naudio.data = touch_s.akey
     return render_template("display_screen.html",
                            form=form,
-                           ptitle="Display Screen customize",
+                           page_title="Display Screen customize",
                            navbar="#snb2",
                            hash=stab,
                            dropdown='#dropdown-lvl2',
@@ -594,17 +556,13 @@ def displayscreen_c(stab):
 
 
 @cust_app.route('/touchscreen_c/<int:stab>', methods=['POST', 'GET'])
-@login_required
+@reject_not_admin
 def touchscreen_c(stab):
     """ view for touch screen customization """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     form = forms.Touch_c(defLang=session.get('lang'))
     ex_functions.mse()
     if stab not in range(0, 6):
-        flash('Error: wrong entry, something went wrong', "danger")
+        flash('Error: wrong entry, something went wrong', 'danger')
         return redirect(url_for('core.root'))
     touch_s = data.Touch_store.query.first()
     if form.validate_on_submit():
@@ -646,7 +604,7 @@ def touchscreen_c(stab):
         db.session.add(touch_s)
         db.session.commit()
         flash("Notice: Touchscreen customization has been updated. ..",
-              "info")
+              'info')
         return redirect(url_for("cust_app.touchscreen_c", stab=0))
     if not form.errors:
         form.touch.data = touch_s.tmp
@@ -674,7 +632,7 @@ def touchscreen_c(stab):
         else:
             form.naudio.data = touch_s.akey
     return render_template("touch_screen.html",
-                           ptitle="Touch Screen customize",
+                           page_title="Touch Screen customize",
                            navbar="#snb2",
                            form=form,
                            dropdown='#dropdown-lvl1',
@@ -685,12 +643,9 @@ def touchscreen_c(stab):
 
 @cust_app.route('/alias', methods=['GET', 'POST'])
 @login_required
+@reject_not_admin
 def alias():
     """ view for aliases customization """
-    if current_user.role_id != 1:
-        flash('Error: only administrator can access the page',
-              "danger")
-        return redirect(url_for('core.root'))
     form = forms.Alias(session.get('lang'))
     aliases = data.Aliases.query.first()
     if form.validate_on_submit():
@@ -710,6 +665,6 @@ def alias():
         form.name.data = aliases.name
         form.number.data = aliases.number
     return render_template(
-        'alias.html', ptitle='Aliases',
+        'alias.html', page_title='Aliases',
         navbar="#snb2", form=form, hash='#da8'
     )

--- a/app/errorsh.py
+++ b/app/errorsh.py
@@ -3,9 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from flask import url_for, flash, redirect, render_template, Blueprint
-from flask import request, Markup, session
-from flask_login import current_user
+from flask import url_for, redirect, render_template, Blueprint
+from flask import session
 
 errorsh_app = Blueprint('errorsh_app', __name__)
 
@@ -18,4 +17,4 @@ def nojs(ino):
             return redirect(s)
         return redirect(url_for('core.root'))
     return render_template('nojs.html',
-                           ptitle='Javascript is disabled')
+                           page_title='Javascript is disabled')

--- a/app/forms.py
+++ b/app/forms.py
@@ -165,7 +165,7 @@ class Display_c(FlaskForm):
         self.display.label = gtranslator.translate('Select a template for Display screen : ', 'en', [defLang])
         self.display.choices = [(t[0], gtranslator.translate(t[1], 'en', [defLang])) for t in tms]
         self.title.label = gtranslator.translate('Enter a title : ', 'en', [defLang])
-        self.title.validators = [ 
+        self.title.validators = [
             InputRequired(gtranslator.translate("Title should be maximum of 300 letters", 'en', [defLang])),
             Length(0, 300)
         ]
@@ -427,17 +427,15 @@ class User_a(FlaskForm):
     def __init__(self, defLang='en', *args, **kwargs):
         super(User_a, self).__init__(*args, **kwargs)
         self.name.label = gtranslator.translate("Enter a unique user name : ", 'en', [defLang])
-        self.name.validators = [InputRequired
-        (gtranslator.translate("Required not less than 5 nor more than 200 letters", 'en', [defLang])),
-        Length(5, 200)]
+        self.name.validators = [InputRequired(gtranslator.translate(
+            "Required not less than 5 nor more than 200 letters", 'en', [defLang])), Length(5, 200)]
         self.password.label = gtranslator.translate("Enter password : ", 'en', [defLang])
-        self.password.validators = [InputRequired(
-            gtranslator.translate("Password must be at least of 5 and at most 15 letters", 'en', [defLang])),
-        Length(5, 15)]
+        self.password.validators = [InputRequired(gtranslator.translate(
+            "Password must be at least of 5 and at most 15 letters", 'en', [defLang])), Length(5, 15)]
         self.role.label = gtranslator.translate("Select a role for the user : ", 'en', [defLang])
-        self.role.validators = [InputRequired
-        (gtranslator.translate("You must select a role to add user in", 'en', [defLang]))]
+        self.role.validators = [InputRequired(gtranslator.translate("You must select a role to add user in", 'en', [defLang]))]
         self.offices.label = gtranslator.translate("Select office to assing the operator to : ", 'en', [defLang])
+        self.offices.validators = [Optional()]
         self.role.choices = [(v.id, v.name) for v in data.Roles.query]
         self.offices.choices = [(o.id, 'Office : ' + str(o.name) + o.prefix) for o in data.Office.query]
 

--- a/gt_cached.json
+++ b/gt_cached.json
@@ -822,6 +822,7 @@
     },
     "Error: fault in search parameters": {
         "ar": "\u062e\u0637\u0623: \u062e\u0637\u0623 \u0641\u064a \u0645\u0639\u0644\u0645\u0627\u062a \u0627\u0644\u0628\u062d\u062b",
+        "en": "Error: fault in search parameters",
         "es": "Error: error en los par\u00e1metros de b\u00fasqueda",
         "fr": "Erreur: erreur dans les param\u00e8tres de recherche",
         "it": "Errore: errore nei parametri di ricerca"
@@ -889,12 +890,14 @@
     },
     "Error: only administrator can access the page": {
         "ar": "\u062e\u0637\u0623: \u064a\u0645\u0643\u0646 \u0644\u0644\u0645\u0633\u0624\u0648\u0644 \u0641\u0642\u0637 \u0627\u0644\u0648\u0635\u0648\u0644 \u0625\u0644\u0649 \u0627\u0644\u0635\u0641\u062d\u0629",
+        "en": "Error: only administrator can access the page",
         "es": "Error: solo el administrador puede acceder a la p\u00e1gina",
         "fr": "Erreur: seul l'administrateur peut acc\u00e9der \u00e0 la page",
         "it": "Errore: solo l'amministratore pu\u00f2 accedere alla pagina"
     },
     "Error: only main Admin account can access the page": {
         "ar": "\u062e\u0637\u0623: \u064a\u0645\u0643\u0646 \u0641\u0642\u0637 \u0644\u062d\u0633\u0627\u0628 \u0627\u0644\u0645\u0634\u0631\u0641 \u0627\u0644\u0631\u0626\u064a\u0633\u064a \u0627\u0644\u0648\u0635\u0648\u0644 \u0625\u0644\u0649 \u0627\u0644\u0635\u0641\u062d\u0629",
+        "en": "Error: only main Admin account can access the page",
         "es": "Error: solo la cuenta de administrador principal puede acceder a la p\u00e1gina",
         "fr": "Erreur: seul le compte administrateur principal peut acc\u00e9der \u00e0 la page",
         "it": "Errore: solo l'account amministratore principale pu\u00f2 accedere alla pagina"
@@ -996,6 +999,7 @@
     },
     "Error: you must reset it, before you delete it ": {
         "ar": "\u062e\u0637\u0623: \u064a\u062c\u0628 \u0639\u0644\u064a\u0643 \u0625\u0639\u0627\u062f\u0629 \u062a\u0639\u064a\u064a\u0646\u0647 \u060c \u0642\u0628\u0644 \u062d\u0630\u0641\u0647",
+        "en": "Error: you must reset it, before you delete it",
         "es": "Error: debe restablecerlo, antes de eliminarlo",
         "fr": "Erreur: vous devez le r\u00e9initialiser avant de le supprimer",
         "it": "Errore: \u00e8 necessario ripristinarlo, prima di eliminarlo"
@@ -1472,6 +1476,7 @@
     },
     "Notice: Sorry, no matching results were found ": {
         "ar": "\u0645\u0644\u0627\u062d\u0638\u0629: \u0639\u0630\u0631\u064b\u0627 \u060c \u0644\u0645 \u064a\u062a\u0645 \u0627\u0644\u0639\u062b\u0648\u0631 \u0639\u0644\u0649 \u0646\u062a\u0627\u0626\u062c \u0645\u0637\u0627\u0628\u0642\u0629",
+        "en": "Notice: Sorry, no matching results were found",
         "es": "Aviso: Lo sentimos, no se encontraron resultados coincidentes",
         "fr": "Avis: D\u00e9sol\u00e9, aucun r\u00e9sultat correspondant n'a \u00e9t\u00e9 trouv\u00e9",
         "it": "Avviso: scusa, non sono stati trovati risultati corrispondenti"
@@ -1499,6 +1504,7 @@
     },
     "Notice: Touchscreen customization has been updated. ..": {
         "ar": "\u0625\u0634\u0639\u0627\u0631: \u062a\u0645 \u062a\u062d\u062f\u064a\u062b \u062a\u062e\u0635\u064a\u0635 \u0634\u0627\u0634\u0629 \u0627\u0644\u0644\u0645\u0633. ..",
+        "en": "Notice: Touchscreen customization has been updated. ..",
         "es": "Aviso: la personalizaci\u00f3n de la pantalla t\u00e1ctil se ha actualizado. ..",
         "fr": "Remarque: la personnalisation de l'\u00e9cran tactile a \u00e9t\u00e9 mise \u00e0 jour. ..",
         "it": "Avviso: la personalizzazione del touchscreen \u00e8 stata aggiornata. .."
@@ -1508,6 +1514,7 @@
     },
     "Notice: admin password has been updated.": {
         "ar": "\u0625\u0634\u0639\u0627\u0631: \u062a\u0645 \u062a\u062d\u062f\u064a\u062b \u0643\u0644\u0645\u0629 \u0645\u0631\u0648\u0631 \u0627\u0644\u0645\u0633\u0624\u0648\u0644.",
+        "en": "Notice: admin password has been updated.",
         "es": "Aviso: la contrase\u00f1a de administrador se ha actualizado.",
         "fr": "Remarque: le mot de passe de l'administrateur a \u00e9t\u00e9 mis \u00e0 jour.",
         "it": "Avviso: la password dell'amministratore \u00e8 stata aggiornata."
@@ -1520,6 +1527,7 @@
     },
     "Notice: all unassigned users got deleted.": {
         "ar": "\u0645\u0644\u0627\u062d\u0638\u0629: \u062a\u0645 \u062d\u0630\u0641 \u062c\u0645\u064a\u0639 \u0627\u0644\u0645\u0633\u062a\u062e\u062f\u0645\u064a\u0646 \u063a\u064a\u0631 \u0627\u0644\u0645\u0639\u064a\u0646\u064a\u0646.",
+        "en": "Notice: all unassigned users got deleted.",
         "es": "Aviso: todos los usuarios no asignados fueron eliminados.",
         "fr": "Remarque: tous les utilisateurs non affect\u00e9s ont \u00e9t\u00e9 supprim\u00e9s.",
         "it": "Avviso: tutti gli utenti non assegnati sono stati eliminati."
@@ -1657,6 +1665,7 @@
     },
     "Notice: user is deleted .": {
         "ar": "\u0625\u0634\u0639\u0627\u0631: \u064a\u062a\u0645 \u062d\u0630\u0641 \u0627\u0644\u0645\u0633\u062a\u062e\u062f\u0645.",
+        "en": "Notice: user is deleted .",
         "es": "Aviso: el usuario es eliminado.",
         "fr": "Avis: l'utilisateur est supprim\u00e9.",
         "it": "Avviso: l'utente \u00e8 cancellato."

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Flask-Colorpicker==0.9
 Flask-Datepicker==0.8
 Flask-Fontpicker==0.2
 Flask-Googletrans==0.9
-Flask-gTTS==0.6
+Flask-gTTS==0.12
 Flask-Less==0.5
 Flask-Login==0.4.0
 Flask-Mail==0.9.1

--- a/templates/admin_u.html
+++ b/templates/admin_u.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
    
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block page_content %}
 {% from "_helpers.html" import render_field %}

--- a/templates/alias.html
+++ b/templates/alias.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_cust.html" import sb_cust with context %}
 {% block sidebar %}

--- a/templates/all_offices.html
+++ b/templates/all_offices.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 {% block head %}
 {{ super() }}
 {{ pagedown.include_pagedown() }}

--- a/templates/csvs.html
+++ b/templates/csvs.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block page_content %}
 {% from "_helpers.html" import render_field %}

--- a/templates/customize.html
+++ b/templates/customize.html
@@ -4,7 +4,7 @@
 
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% from "_beloadingNotifier.html" import beloadingNotifier %}
 {% block head %}

--- a/templates/display.html
+++ b/templates/display.html
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/.  -->
 {% extends "base_s.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 
 
 {% block page_content %}
@@ -38,13 +38,14 @@
 				fetch(window.location.origin + '/feed')
 				.then(function (r) { return r.json() }).then(function (j) {
 					if (j.replay==='yes') {
-						aplayer.replay()
+						if (aplayer) aplayer.replay()
 						fetch(window.location.origin + '/feed/1')
 					}
 				}).catch(function (e) { console.warn(e.message) })
 			}, 500)
 			if (aplayer) aplayer.exit(false)
 			Promise.all(langs.map(function (lang, i) {
+				console.log(data.con)
 				return fetch(window.location.origin + '/gtts/' + lang + '/' + data.cot + TTS[lang] + data.con)
 				.then(function (resp) {
 					return resp.json()

--- a/templates/display_screen.html
+++ b/templates/display_screen.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block head %}
 {% from '_uniqueness.html' import uniqueness %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 {% from "_beloadingNotifier.html" import beloadingNotifier %}
 <html>
     <head>
-        <title>{% block title %} FQM - {{ ptitle }} {% endblock %}</title>
+        <title>{% block title %} FQM - {{ page_title }} {% endblock %}</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-compatible" content="IE=edge">

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% from "_beloadingNotifier.html" import beloadingNotifier %}
 {% block head %}

--- a/templates/multimedia.html
+++ b/templates/multimedia.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
    
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 {% import "_macros.html" as macros %}
 
 {%- from "sb_cust.html" import sb_cust with context %}

--- a/templates/nojs.html
+++ b/templates/nojs.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <html>
-<title>{% block title %} FQM - {{ ptitle }} {% endblock %}</title>
+<title>{% block title %} FQM - {{ page_title }} {% endblock %}</title>
 
 <head>
 <meta charset="utf-8">

--- a/templates/office_add.html
+++ b/templates/office_add.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_manage.html" import sb_manage with context %}
 {% block sidebar %}

--- a/templates/offices.html
+++ b/templates/offices.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 {% block head %}
 {{ super() }}
 {{ pagedown.include_pagedown() }}

--- a/templates/operators.html
+++ b/templates/operators.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 {% import "_macros.html" as macros %}
 
 {% block head %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 {% block head %}
 {{ super() }}
 {{ datepicker.loader() }}

--- a/templates/search_r.html
+++ b/templates/search_r.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 {% block head %}
 {{ super() }}
 {{ pagedown.include_pagedown() }}

--- a/templates/slide_add.html
+++ b/templates/slide_add.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block head %}
 {% from '_uniqueness.html' import uniqueness %}

--- a/templates/slide_settings.html
+++ b/templates/slide_settings.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_cust.html" import sb_cust with context %}
 {% block sidebar %}

--- a/templates/slideshow.html
+++ b/templates/slideshow.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 {% import "_macros.html" as macros %}
 
 {%- from "sb_cust.html" import sb_cust with context %}

--- a/templates/task_add.html
+++ b/templates/task_add.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_manage.html" import sb_manage with context %}
 {% block sidebar %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 {% block head %}
 {{ super() }}
 {{ pagedown.include_pagedown() }}

--- a/templates/ticket.html
+++ b/templates/ticket.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_cust.html" import sb_cust with context %}
 {% block sidebar %}

--- a/templates/touch.html
+++ b/templates/touch.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base_s.html" %}
-{% block title %} FQM - {{ ptitle }} {% endblock %}
+{% block title %} FQM - {{ page_title }} {% endblock %}
 {% block head %}
 {{ super() }}
 <script src="{{ url_for('static', filename='extFunctions.js') }}" type='text/javascript'></script>

--- a/templates/touch_screen.html
+++ b/templates/touch_screen.html
@@ -3,7 +3,7 @@
 - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block head %}
 {% from '_uniqueness.html' import uniqueness %}

--- a/templates/user_add.html
+++ b/templates/user_add.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {% block page_content %}
 {% from "_helpers.html" import render_field %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 {% import "_macros.html" as macros %}
 
 

--- a/templates/video.html
+++ b/templates/video.html
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 {% extends "base.html" %}
-{% block title %} FQM - {{ ptitle  }} {% endblock %}
+{% block title %} FQM - {{ page_title  }} {% endblock %}
 
 {%- from "sb_cust.html" import sb_cust with context %}
 {% block sidebar %}

--- a/todo_now.md
+++ b/todo_now.md
@@ -5,9 +5,12 @@
 - [x] Migrate code from Python 2 and PySide to Python 3 and PyQT5 `(2019-12-22)`
 - [x] Customization multimedia page bug `(2019-12-22)`
 - [x] Use latest `flask_minify` to fix high memory consumption `(2019-12-22)`
-- [x] Use latest `audio_sequence` to fix overwriting files `(2019-12-22)`
+- [ ] Use latest `audio_sequence` to fix overwriting files. And replace `fetch` with `ajax` for IE
 - [x] Use one source of truth for all translations GUI and app `gt_cached.json` `(2019-12-23)`
-- [ ] Use mixIns to modularize and cleanup backend
+- [x] Use mixIns to modularize and cleanup backend `(2019-12-24)`
+- [x] Fix `/feed` and announcements after migration to py3 `(2019-12-24)`
+- [x] Fix reset office from within itself `(2019-12-24)`
+- [x] Fix search SQLAlchemy safe parameters, after migration to Python 3 bug `(2019-12-24)`
 - [ ] Printer failsafe should display error in debug mode
 - [ ] Fix last ticket to pull getting stuck
 - [ ] Refactor `reddit-wallpapers` for cross-browse compatibility
@@ -37,4 +40,4 @@
 - [ ] Initial integration test suite:
 > - [ ] Add testing db switch
 > - [ ] Use `Flask-Testing`
-> - [ ] Cover all Administrate endpoints
+> - [ ] Cover and refactor all Administrate endpoints


### PR DESCRIPTION
- Rename `ptitle` to `page_title` in all templates and views
- Bump `flask-gtts` to `0.12` to fix ecnoding py3 bug
- Add mixins helper and replace `operator`, `admin` view validation with them.
- Fix reset office from within itself bug
- Fix search page sqlalchemy safe parameters, py3 bug