### PR TITLE
Fix `popen` win7 printer bug. Replace `popen` with local executer.

### DIFF
--- a/app/printer.py
+++ b/app/printer.py
@@ -12,30 +12,11 @@ from escpos.printer import Dummy
 from datetime import datetime
 from bidi.algorithm import get_display
 from PIL import Image, ImageDraw, ImageFont
-from os import remove, getcwd, path, name, popen, system
+from os import remove, getcwd, path, name, system
 
 from app.utils import absolute_path, get_with_alias
 from app.constants import VERSION
 from app.middleware import gtranslator
-
-
-def get_windows_printers():
-    ''' List Windows available printers using `wmic` system command.
-
-    Returns
-    -------
-        List of available printers on Windows.
-    '''
-    printers = []
-
-    with popen('wmic printer get sharename') as output:
-        printers += [
-            p.strip()
-            for p in output.read().split('\n\n')[1:]
-            if p.strip()
-        ]
-
-    return printers
 
 
 class find_class(object):

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+from uuid import uuid4
 from traceback import TracebackException
 from datetime import datetime
 from random import randint
@@ -16,6 +17,36 @@ from flask import current_app
 
 import app.database as data
 from app.middleware import db
+
+
+def execute(command, parser=None):
+    ''' Utility to execute a system command and get its output without
+        breaking any ongoing execution loops.
+
+    Parameter
+    ---------
+        command: str
+            system command to execute.
+        parser: str
+            factor to parse the output and clean it with.
+
+    Returns
+    -------
+        System command output as a string or a list if parsed.
+    '''
+    temp_file = f'{uuid4()}'.replace('-', '')
+    output = ''
+    parsed = []
+
+    os.system(f'{command} > "{temp_file}"')
+    with open(temp_file, 'r') as file:
+        output += file.read()
+    os.remove(temp_file)
+
+    if parser:
+        parsed += [o.strip() for o in output.split(parser) if o.strip()]
+
+    return parsed if parser else output
 
 
 def absolute_path(relative_path):

--- a/app/views/core.py
+++ b/app/views/core.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-from random import choice
 from sys import platform
 from datetime import datetime
 from flask import url_for, flash, render_template, redirect, session, jsonify, Blueprint, current_app
@@ -12,11 +11,10 @@ from flask_login import current_user, login_required, login_user
 
 import app.forms as forms
 import app.database as data
-from app.printer import (
-    assign, printit, printit_ar, print_ticket_windows, print_ticket_windows_ar,
-    get_windows_printers)
+from app.printer import assign, printit, printit_ar, print_ticket_windows, print_ticket_windows_ar
 from app.middleware import db
 from app.helpers import reject_no_offices, reject_operator, is_operator, reject_not_admin
+from app.utils import execute
 
 
 core = Blueprint('core', __name__)
@@ -132,7 +130,8 @@ def serial(t_id):
             langu = data.Printer.query.first().langu
             # to solve Linux printer permissions
             if os.name == 'nt':
-                if get_windows_printers():
+                # NOTE: To list all windows printers
+                if execute('wmic printer get sharename', parser='\n\n')[1:]:
                     if langu == 'ar':
                         print_ticket_windows_ar(
                             q.product,

--- a/app/views/customize.py
+++ b/app/views/customize.py
@@ -13,8 +13,8 @@ from werkzeug import secure_filename
 import app.forms as forms
 import app.database as data
 from app.middleware import db, files
-from app.printer import listp, get_windows_printers
-from app.utils import absolute_path, getFolderSize
+from app.printer import listp
+from app.utils import absolute_path, getFolderSize, execute
 from app.constants import SUPPORTED_MEDIA_FILES
 from app.helpers import reject_not_admin
 
@@ -39,7 +39,8 @@ def customize():
 @reject_not_admin
 def ticket():
     """ view of ticket customization """
-    printers = get_windows_printers() if os.name == 'nt' else listp()
+    printers = execute('wmic printer get sharename',
+                       parser='\n\n')[1:] if os.name == 'nt' else listp()
     form = forms.Printer_f(printers, session.get('lang'))
     tc = data.Touch_store.query.first()
     pr = data.Printer.query.first()


### PR DESCRIPTION
- Fix `popen` win7 printer bug.
- Replace `popen` with local executer.
