### PR TITLE
Add encoding to `execute`. Fix `wmic` encoding `utf-16`.

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -19,9 +19,10 @@ import app.database as data
 from app.middleware import db
 
 
-def execute(command, parser=None):
-    ''' Utility to execute a system command and get its output without
-        breaking any ongoing execution loops.
+def execute(command, parser=None, encoding='utf-8'):
+    '''
+    Utility to execute a system command and get its output without
+    breaking any ongoing execution loops.
 
     Parameter
     ---------
@@ -29,6 +30,8 @@ def execute(command, parser=None):
             system command to execute.
         parser: str
             factor to parse the output and clean it with.
+        encoding: str
+            encoding to read the command output with.
 
     Returns
     -------
@@ -39,7 +42,7 @@ def execute(command, parser=None):
     parsed = []
 
     os.system(f'{command} > "{temp_file}"')
-    with open(temp_file, 'r') as file:
+    with open(temp_file, 'r', encoding=encoding) as file:
         output += file.read()
     os.remove(temp_file)
 

--- a/app/views/core.py
+++ b/app/views/core.py
@@ -131,7 +131,7 @@ def serial(t_id):
             # to solve Linux printer permissions
             if os.name == 'nt':
                 # NOTE: To list all windows printers
-                if execute('wmic printer get sharename', parser='\n\n')[1:]:
+                if execute('wmic printer get sharename', parser='\n', encoding='utf-16')[1:]:
                     if langu == 'ar':
                         print_ticket_windows_ar(
                             q.product,

--- a/app/views/customize.py
+++ b/app/views/customize.py
@@ -40,7 +40,8 @@ def customize():
 def ticket():
     """ view of ticket customization """
     printers = execute('wmic printer get sharename',
-                       parser='\n\n')[1:] if os.name == 'nt' else listp()
+                       parser='\n',
+                       encoding='utf-16')[1:] if os.name == 'nt' else listp()
     form = forms.Printer_f(printers, session.get('lang'))
     tc = data.Touch_store.query.first()
     pr = data.Printer.query.first()


### PR DESCRIPTION
- Add encoding to `execute`.
- Fix `wmic` encoding `utf-16`.