### PR TITLE
Fix common task generating, pulling tickets and Add test coverage

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -47,6 +47,12 @@ class Task(db.Model, Mixin):
     def common(self):
         return len(self.offices) > 1
 
+    @classmethod
+    def get_first_common(cls):
+        for task in cls.query:
+            if task.common:
+                return task
+
     def least_tickets_office(self):
         self.offices.sort(key=lambda o: Serial.query.filter_by(office_id=o.id).count())
         return self.offices[0]

--- a/tests/common.py
+++ b/tests/common.py
@@ -29,6 +29,7 @@ PREFIXES = list(map(lambda i: chr(i).upper(), range(97,123)))
 
 MODULES = [Waiting, Serial, User, Operators, Task, Office]
 DB_PATH = absolute_path('testing.sqlite')
+TEST_REPEATS = 11
 
 
 @pytest.fixture

--- a/tests/core.py
+++ b/tests/core.py
@@ -1,6 +1,7 @@
+import pytest
 from random import choice
 
-from .common import client
+from .common import client, NAMES, TEST_REPEATS
 from app.database import Task, Office, Serial
 from app.middleware import db
 from app.utils import ids
@@ -19,6 +20,7 @@ def test_reset_office(client):
     assert Serial.query.filter(Serial.office_id == office.id, Serial.number != 100)\
                         .count() == 0
 
+
 def test_reset_task(client):
     with client.application.app_context():
         task = Task.query.first()
@@ -33,6 +35,7 @@ def test_reset_task(client):
     assert Serial.query.filter(Serial.task_id == task.id, Serial.number != 100)\
                        .count() == 0
 
+
 def test_reset_all(client):
     with client.application.app_context():
         all_tickets = Serial.query.all()
@@ -42,3 +45,64 @@ def test_reset_all(client):
     assert response.status == '200 OK'
     assert Serial.query.count() != len(all_tickets)
     assert Serial.query.count() == Task.query.count()
+
+
+@pytest.mark.parametrize('_', range(TEST_REPEATS))
+def test_generate_new_tickets(_, client):
+    with client.application.app_context():
+        tickets_before = Serial.query.order_by(Serial.number.desc()).all()
+        last_ticket = Serial.query.order_by(Serial.number.desc()).first()
+        random_task = choice(Task.query.all())
+
+    name = choice(NAMES)
+    response = client.post(f'/serial/{random_task.id}', data={
+        'name': name
+    }, follow_redirects=True)
+
+    assert response.status == '200 OK'
+    assert Serial.query.count() > len(tickets_before)
+    assert Serial.query.order_by(Serial.number.desc())\
+                       .first()\
+                       .number == (last_ticket.number + 1)
+
+
+@pytest.mark.parametrize('_', range(TEST_REPEATS))
+def test_pull_tickets_from_all(_, client):
+    with client.application.app_context():
+        ticket_to_be_pulled = Serial.query.order_by(Serial.number)\
+                                          .filter(Serial.number != 100, Serial.p != True)\
+                                          .first()
+
+    response = client.get(f'/pull', follow_redirects=True)
+
+    assert response.status == '200 OK'
+    assert ticket_to_be_pulled is not None
+    assert ticket_to_be_pulled.p is False
+    assert Serial.query.filter_by(number=ticket_to_be_pulled.number,
+                                  office_id=ticket_to_be_pulled.office_id,
+                                  task_id=ticket_to_be_pulled.task_id,
+                                  p=True)\
+                       .order_by(Serial.number)\
+                       .first() is not None
+
+
+@pytest.mark.parametrize('_', range(TEST_REPEATS))
+def test_pull_tickets_from_commmon_task(_, client):
+    with client.application.app_context():
+        task = Task.get_first_common()
+        ticket_to_be_pulled = Serial.query.order_by(Serial.number)\
+                                          .filter(Serial.number != 100, Serial.p != True,
+                                                  Serial.task_id == task.id)\
+                                          .first()
+
+    response = client.get(f'/pull/{task.id}/{choice(task.offices).id}', follow_redirects=True)
+
+    assert response.status == '200 OK'
+    assert ticket_to_be_pulled is not None
+    assert ticket_to_be_pulled.p is False
+    assert Serial.query.filter_by(number=ticket_to_be_pulled.number,
+                                  office_id=ticket_to_be_pulled.office_id,
+                                  task_id=ticket_to_be_pulled.task_id,
+                                  p=True)\
+                       .order_by(Serial.number)\
+                       .first() is not None

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -53,16 +53,7 @@ def test_update_task(client):
 
 def test_update_common_task_offices(client):
     with client.application.app_context():
-        # find a common task
-        common_task = None
-        tasks = Task.query.all()
-
-        while not common_task:
-            task = tasks.pop()
-
-            if len(task.offices) > 1:
-                common_task = task
-
+        task = Task.get_first_common()
         unchecked_office = task.offices[0]
         checked_office = task.offices[1]
         unchecked_office_tickets_numbers = [


### PR DESCRIPTION
- Refactor `/serial` to increment tickets based on the last global ticket number, if common task.
- Fix `/pull` to not include initial tickets `100` in `Waiting`
- Refactor `/pull` to fallback to `Serial` record if it wasn't pushed to `Waiting` list. Should resolve #13
- Add test coverage for generating and pulling tickets

**Manual testing with the database file triggering the issue**:

![testing_last_ticekt_stuck](https://user-images.githubusercontent.com/26286907/73347767-354eaf00-4299-11ea-98b2-ea0fea2aa7d9.gif)

