### PR TITLE
Major `core.pull` refactoring and Add strict pulling

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -16,3 +16,10 @@ SUPPORTED_MEDIA_FILES = [
     ['wav', 'WAV', 'mp3', 'MP3'],
     ['mp4', 'MP4', 'AVI', 'avi', 'webm', 'WEBM']
 ]
+
+USER_ROLES = {
+    # NOTE: User roles keyed with their ids.
+    1: 'Administrator',
+    2: 'Monitor',
+    3: 'Operator'
+}

--- a/app/utils.py
+++ b/app/utils.py
@@ -294,6 +294,20 @@ def mse():
     db.session.commit()
 
 
+def create_default_records():
+    ''' create database necessary records, if not existing. '''
+    tables = [data.Display_store, data.Touch_store, data.Slides_c,
+              data.Settings, data.Vid, data.Waiting_c, data.Printer,
+              data.Aliases]
+
+    # NOTE: Create default records, if non-existing.
+    for table in tables:
+        if not table.query.first():
+            db.session.add(table())
+    db.session.commit()
+    data.Roles.load_roles()
+
+
 def getFolderSize(folder, safely=False):
     # -- get a folder size
     if safely and not os.path.isdir(folder):

--- a/gt_cached.json
+++ b/gt_cached.json
@@ -1511,6 +1511,20 @@
     "Notice: Notification got Enabled successfully": {
         "en": "Notice: Notification got Enabled successfully"
     },
+    "Notice: Setting got Disabled successfully.": {
+        "ar": "\u0625\u0634\u0639\u0627\u0631: \u0625\u0639\u062f\u0627\u062f \u062d\u0635\u0644\u062a \u0645\u0639\u0637\u0644 \u0628\u0646\u062c\u0627\u062d.",
+        "en": "Notice: Setting got Disabled successfully.",
+        "es": "Aviso: Ajuste qued\u00f3 inhabilitado satisfactoriamente.",
+        "fr": "Important: Le r\u00e9glage d\u00e9sactiv\u00e9 avec succ\u00e8s obtenu.",
+        "it": "Avviso: Impostazione ottenuto disattivata con successo."
+    },
+    "Notice: Setting got Enabled successfully.": {
+        "ar": "\u0625\u0634\u0639\u0627\u0631: \u0625\u0639\u062f\u0627\u062f \u062d\u0635\u0644\u062a \u0639\u0644\u0649 \u062a\u0645\u0643\u064a\u0646 \u0628\u0646\u062c\u0627\u062d.",
+        "en": "Notice: Setting got Enabled successfully.",
+        "es": "Aviso: Ajuste consigui\u00f3 permitido con \u00e9xito.",
+        "fr": "Important: Le r\u00e9glage obtenu activ\u00e9 avec succ\u00e8s.",
+        "it": "Avviso: Impostazione ottenuto attivato con successo."
+    },
     "Notice: Sorry, no matching results were found ": {
         "ar": "\u0645\u0644\u0627\u062d\u0638\u0629: \u0639\u0630\u0631\u064b\u0627 \u060c \u0644\u0645 \u064a\u062a\u0645 \u0627\u0644\u0639\u062b\u0648\u0631 \u0639\u0644\u0649 \u0646\u062a\u0627\u0626\u062c \u0645\u0637\u0627\u0628\u0642\u0629",
         "en": "Notice: Sorry, no matching results were found",
@@ -2627,6 +2641,13 @@
         "es": "detener el servidor",
         "fr": "arr\u00eate le serveur",
         "it": "fermare il server"
+    },
+    "Strict Tasks Pulling": {
+        "ar": "\u0627\u0644\u0645\u0647\u0627\u0645 \u0635\u0627\u0631\u0645\u0629 \u0633\u062d\u0628",
+        "en": "Strict Tasks Pulling",
+        "es": "Tareas estrictas Tirando",
+        "fr": "T\u00e2ches strictes Pulling",
+        "it": "Compiti severe Pulling"
     },
     "Subtitle : Secondary text box will be displayed under main title": {
         "ar": "\u0639\u0646\u0648\u0627\u0646 \u0641\u0631\u0639\u064a: \u0633\u064a\u062a\u0645 \u0639\u0631\u0636 \u0645\u0631\u0628\u0639 \u0627\u0644\u0646\u0635 \u0627\u0644\u062b\u0627\u0646\u0648\u064a \u062a\u062d\u062a \u0627\u0644\u0639\u0646\u0648\u0627\u0646 \u0627\u0644\u0631\u0626\u064a\u0633\u064a",

--- a/templates/base.html
+++ b/templates/base.html
@@ -129,11 +129,18 @@
                                         </a>
                                     </li>
                                     {% if current_user.id == 1 %}
+                                    <li class="dropdown-header">( {{ translate('Strict Tasks Pulling', 'en', [defLang]) }} )</li>
+                                    <li>
+                                        <a href="{{ url_for('core.settings', setting='strict_pulling', togo=current_path.replace('/', '(')) }}">
+                                            <span class="fa fa-lock"></span>
+                                            {{ translate('Disable' if settings.strict_pulling == True else 'Enable', 'en', [defLang]) }}
+                                        </a>
+                                    </li>
                                     <li class="dropdown-header">( {{ translate('Notifications', 'en', [defLang]) }} )</li>
                                     <li>
-                                        <a href="{{ url_for('core.notifications', togo=current_path.replace('/', '(')) }}">
+                                        <a href="{{ url_for('core.settings', setting='notifications', togo=current_path.replace('/', '(')) }}">
                                             <span class="fa fa-bell"></span>
-                                            {{ translate('Disable' if notifications == True else 'Enable', 'en', [defLang]) }}
+                                            {{ translate('Disable' if settings.notifications == True else 'Enable', 'en', [defLang]) }}
                                         </a>
                                     </li>
                                     {% endif %}

--- a/templates/offices.html
+++ b/templates/offices.html
@@ -144,8 +144,8 @@
 	    </div>
 	    <div class="panel-footer text-center">
 			{{ panelFooter([
-			[[translate('Tasks total', 'en', [defLang]), len(ooid.tasks)], [translate('Tickets total', 'en', [defLang]), serial.filter_by(office_id=o_id).count()]],
-			[[translate('Processed', 'en', [defLang]), serial.filter_by(p=True, office_id=o_id).count()], [translate('Waiting', 'en', [defLang]), serial.filter_by(p=False, office_id=o_id).count()]]
+			[[translate('Tasks total', 'en', [defLang]), len(ooid.tasks)], [translate('Tickets total', 'en', [defLang]), serial.count()]],
+			[[translate('Processed', 'en', [defLang]), serial.filter_by(p=True).count()], [translate('Waiting', 'en', [defLang]), serial.filter_by(p=False).count()]]
 			], toWarn=translate('Waiting', 'en', [defLang])) }}
 			<div class="row text-center">
 		    	<div class="pagination">

--- a/templates/sb_manage.html
+++ b/templates/sb_manage.html
@@ -70,15 +70,10 @@
 				{{ office.id }}.{{ translate('Office', 'en', [defLang]) }}  {{ office.prefix }}{{ office.name }}
 				<span class="caret"></span>
 				<!-- To solve counting all the common and non-common tasks tickets -->
-				{% set counter = namespace(a=0) %}
-				{% for toTask in office.tasks %}
-					{% if checkId(office.id, toTask.offices) %}
-				    {% set counter.a = counter.a + serial.filter_by(p=False, task_id=toTask.id).count() %}
-					{% endif %}
-				{% endfor %}
-				{% if counter.a > 0 %}
+				{% set total_tickets = Serial.all_office_tickets(office.id).filter_by(p=False).count() %}
+				{% if total_tickets > 0 %}
 				<span class="badge pull-right">
-					{{ counter.a }}
+					{{ total_tickets }}
 				</span>
 				{% endif %}
 			    </a>
@@ -129,9 +124,10 @@
 						<a href="{{ url_for('core.pull', o_id=task.id, ofc_id=office.id) }}">
 								<span class="fa fa-minus"></span>
 								{{ translate('Pull a ticket', 'en', [defLang]) }}
-								{% if serial.filter_by(p=False, task_id=task.id).count() >= 1 %}
+								{% set task_tickets = Serial.all_task_tickets(office.id, task.id).filter_by(p=False).count() %}
+								{% if task_tickets >= 1 %}
 								<span class="badge pull-right">
-									{{ serial.filter_by(p=False, task_id=task.id).count() }}
+									{{ task_tickets }}
 								</span>
 								{% endif %}
 						</a>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -131,7 +131,7 @@ $(document).ready(function () {
 			], toWarn=translate('Waiting', 'en', [defLang])) }}
 			<div class="row text-center">
 		    	<div class="pagination">
-					{{ macros.pagination_widget(pagination, '.task', o_id=o_id) }}
+					{{ macros.pagination_widget(pagination, '.task', o_id=o_id, ofc_id=office.id) }}
 		    	</div>
 			</div>
 	    </div>

--- a/tests/common.py
+++ b/tests/common.py
@@ -136,13 +136,15 @@ def fill_tickets(entry_number=100):
     db.session.commit()
 
     # Filling the waiting tickets stack
-    tickets_to_fill = Serial.query.filter_by(p=False)\
+    tickets_to_fill = Serial.query.filter(Serial.p == False,
+                                          Serial.number != 100)\
                                   .order_by(Serial.number)\
                                   .limit(11 - Waiting.query.count())
 
     for ticket in tickets_to_fill:
-        db.session.add(Waiting(number=ticket.number, office_id=ticket.office_id,
-                               task_id=ticket.task_id, name=ticket.name, n=ticket.n))
+        if 10 >= Waiting.query.count():
+            db.session.add(Waiting(number=ticket.number, office_id=ticket.office_id,
+                                   task_id=ticket.task_id, name=ticket.name, n=ticket.n))
     db.session.commit()
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -2,7 +2,7 @@ import pytest
 from random import choice
 
 from .common import client, NAMES, TEST_REPEATS
-from app.database import Task, Office, Serial
+from app.database import Task, Office, Serial, Waiting, Settings
 from app.middleware import db
 from app.utils import ids
 
@@ -72,6 +72,8 @@ def test_pull_tickets_from_all(_, client):
         ticket_to_be_pulled = Serial.query.order_by(Serial.number)\
                                           .filter(Serial.number != 100, Serial.p != True)\
                                           .first()
+        in_waiting = Waiting.query.filter_by(number=ticket_to_be_pulled.number)\
+                                  .first()
 
     response = client.get(f'/pull', follow_redirects=True)
 
@@ -84,25 +86,70 @@ def test_pull_tickets_from_all(_, client):
                                   p=True)\
                        .order_by(Serial.number)\
                        .first() is not None
+    assert Waiting.query.count() == (10 if in_waiting else 11)  # NOTE: last ticket pulled deducted
 
 
 @pytest.mark.parametrize('_', range(TEST_REPEATS))
-def test_pull_tickets_from_commmon_task(_, client):
+def test_pull_tickets_from_common_task(_, client):
     with client.application.app_context():
         task = Task.get_first_common()
+        office = choice(task.offices)
         ticket_to_be_pulled = Serial.query.order_by(Serial.number)\
                                           .filter(Serial.number != 100, Serial.p != True,
                                                   Serial.task_id == task.id)\
                                           .first()
+        in_waiting = Waiting.query.filter_by(number=ticket_to_be_pulled.number)\
+                                  .first()
 
-    response = client.get(f'/pull/{task.id}/{choice(task.offices).id}', follow_redirects=True)
+    response = client.get(f'/pull/{task.id}/{office.id}', follow_redirects=True)
+    pulled_ticket = Serial.query.filter_by(number=ticket_to_be_pulled.number,
+                                           office_id=office.id,
+                                           task_id=task.id,
+                                           p=True)\
+                                .order_by(Serial.number)\
+                                .first()
 
     assert response.status == '200 OK'
     assert ticket_to_be_pulled is not None
     assert ticket_to_be_pulled.p is False
-    assert Serial.query.filter_by(number=ticket_to_be_pulled.number,
-                                  office_id=ticket_to_be_pulled.office_id,
-                                  task_id=ticket_to_be_pulled.task_id,
-                                  p=True)\
-                       .order_by(Serial.number)\
-                       .first() is not None
+    assert pulled_ticket is not None
+    assert pulled_ticket.task_id == task.id
+    assert pulled_ticket.office_id == office.id
+    assert Waiting.query.count() == (10 if in_waiting else 11)  # NOTE: last ticket pulled deducted
+
+
+@pytest.mark.parametrize('_', range(TEST_REPEATS))
+def test_pull_common_task_strict_pulling(_, client):
+    with client.application.app_context():
+        # NOTE: Enabling strict pulling
+        settings = Settings.get()
+        settings.strict_pulling = True
+        db.session.commit()
+
+        # NOTE: Finding the proper next common ticket to be pulled
+        ticket_to_be_pulled = None
+        tickets = Serial.query.order_by(Serial.number)\
+                              .filter(Serial.number != 100, Serial.p != True)\
+                              .all()
+
+        for ticket in tickets:
+            task = Task.get(ticket.task_id)
+            office = Office.get(ticket.office_id)
+
+            if task.common:
+                ticket_to_be_pulled = ticket
+                break
+
+    response = client.get(f'/pull/{task.id}/{office.id}', follow_redirects=True)
+    pulled_ticket = Serial.query.filter_by(number=ticket_to_be_pulled.number,
+                                           office_id=office.id,
+                                           task_id=task.id,
+                                           p=True)\
+                                .order_by(Serial.number)\
+                                .first()
+
+    assert response.status == '200 OK'
+    assert pulled_ticket is not None
+    assert pulled_ticket.task_id == task.id
+    assert pulled_ticket.office_id == office.id
+    assert Waiting.query.count() == 10

--- a/todo_now.md
+++ b/todo_now.md
@@ -5,12 +5,13 @@
 - [x] ~~Fix common task tickets bread crumbs counter~~ (2020-01-31)
 > Default tickets incrementing behavior was altered which resolved the issue
 - [ ] Refactor `manage` and `core` endpoints
-- [x] Always hit tasks with office id to fix possible random redirection
+- [x] Always hit tasks with office id to fix possible random redirection (2020-02-02)
 - [ ] Arabic GUI fonts on Windows
 
 
 ### To Add :
 
+- [x] Add flag setting to enable or disable common office strict tickets pulling (2020-02-05)
 - [ ] Pre-load waiting tickets from `/feed` to reduce text-to-speech generation latency.
 - [ ] Add option to disable all the transition effects and reddit-wallpapers
 - [ ] Pull random ticket from `tasks` or `offices`


### PR DESCRIPTION
- Add a flag setting to enable or disable common tasks strict pulling
- Update and add pulling test-coverage
- Fix reassigning pulling office to pulled tickets, resolves #58
- Add workaround settings module migration

<hr />

**Strict task pulling**:
a feature that allows an admin to enable or disable, loose pulling for common tasks tickets across offices that shares a given common task.

![capture_strict_pulling](https://user-images.githubusercontent.com/26286907/73864479-c651f700-4852-11ea-94cc-22907a5dd42c.png)

**Demo**:

![demo_strict_pulling](https://user-images.githubusercontent.com/26286907/73864462-bafecb80-4852-11ea-8024-d9d2d425b16d.gif)

