### PR TITLE
Fix display screen task name swapping, resolves #65

### DIFF
--- a/app/views/core.py
+++ b/app/views/core.py
@@ -296,7 +296,7 @@ def feed():
     # To fix `uniqueness` not picking up the change in passed waiting list
     waiting_list_parameters[f'w{len(waiting_list_parameters)}'] = name_or_number
 
-    return jsonify(con=office_name, cot=task_name, cott=name_or_number,
+    return jsonify(con=office_name, cot=name_or_number, cott=task_name,
                    replay='yes' if display_settings.r_announcement else 'no',
                    **waiting_list_parameters)
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -229,8 +229,8 @@ def test_feed_stream_tickets(client):
 
     assert response.status == '200 OK'
     assert response.json.get('con') == current_ticket.oname
-    assert response.json.get('cot') == current_ticket.tname
-    assert response.json.get('cott') == getattr(current_ticket,
+    assert response.json.get('cott') == current_ticket.tname
+    assert response.json.get('cot') == getattr(current_ticket,
                                                 'name' if current_ticket.n
                                                 else 'ticket')
 


### PR DESCRIPTION
- Fix display screen task name swapping, resolves #65

![fix_display_screen_task_and_ticket](https://user-images.githubusercontent.com/26286907/74085557-013e6f80-4a8b-11ea-96ca-a6bf84272018.gif)
