### PR TITLE
Fix unused media files stuck. And fix none-responsive video style.

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -12,9 +12,10 @@ SUPPORTED_LANGUAGES = {
 
 SUPPORTED_MEDIA_FILES = [
     # NOTE: The officially supported media files.
-    ['jpg', 'JPG', 'png', 'PNG'],
-    ['wav', 'WAV', 'mp3', 'MP3'],
-    ['mp4', 'MP4', 'AVI', 'avi', 'webm', 'WEBM']
+    ['jpg', 'JPG', 'png', 'PNG'],  # Images
+    ['wav', 'WAV', 'mp3', 'MP3'],  # Audio
+    ['mp4', 'MP4', 'AVI', 'avi',
+     'webm', 'WEBM', 'mkv', 'MKV']  # Video
 ]
 
 USER_ROLES = {

--- a/app/database.py
+++ b/app/database.py
@@ -410,7 +410,7 @@ class Touch_store(db.Model):
                  mcolor="rgb(255, 255, 0)", tcolor="btn-danger",
                  message="Ticket has been issued, pleas wait your turn",
                  audio="false", hfont="El Messiri", mfont="Mada",
-                 tfont="Amiri", ikey=1, tmp=2, akey=5,
+                 tfont="Amiri", ikey=None, tmp=2, akey=None,
                  mduration="3000", bgcolor="rgb(0, 0, 0)", p=False, n=True):
         self.id = 0
         self.hfont = hfont
@@ -488,7 +488,7 @@ class Display_store(db.Model):
                  scolor="rgb(224, 224, 224)", audio="false",
                  hfont="El Messiri", tfont="Mada", repeats="3", effect="fade",
                  sfont="Amiri", mduration="3000", rrate="2000",
-                 announce="en-us", ikey=4, vkey=6, akey=5,
+                 announce="en-us", ikey=4, vkey=None, akey=None,
                  anr=2, anrt="each", bgcolor="rgb(0,0,0)", tmp=1):
         self.id = 0
         self.tfont = tfont
@@ -598,7 +598,7 @@ class Vid(db.Model):
                                                ondelete='cascade'),
                      nullable=True)
 
-    def __init__(self, vname="Tokyo.mp4", enable=1, ar=1, controls=1,
+    def __init__(self, vname="", enable=1, ar=1, controls=1,
                  mute=2, vkey=6):
         self.vname = vname
         self.enable = enable

--- a/app/forms.py
+++ b/app/forms.py
@@ -553,9 +553,9 @@ class Video(FlaskForm):
         (2, "Disable")]]
         vds = []
         if data.Media.query.filter_by(vid=True).count() >= 1:
+            vds.append((00, gtranslator.translate("Do not assign video", 'en', [defLang])))
             for v in data.Media.query.filter_by(vid=True):
                 vds.append((v.id, str(v.id) + ".  " + v.name))
-            vds.append((00, gtranslator.translate("Do not assign video", 'en', [defLang])))
         else:
             vds.append((00, gtranslator.translate("No videos were found", 'en', [defLang])))
         self.video.choices = vds

--- a/app/views/customize.py
+++ b/app/views/customize.py
@@ -108,7 +108,8 @@ def video():
     if form.validate_on_submit():
         if form.video.data == 00:
             vdb.enable = 2
-            vdb.vkey = 00
+            vdb.vkey = None
+            vdb.vname = ''
         else:
             vdb.vkey = form.video.data
             vdb.enable = form.enable.data

--- a/gt_cached.json
+++ b/gt_cached.json
@@ -1643,6 +1643,7 @@
     },
     "Notice: multimedia file been removed.": {
         "ar": "\u0625\u0634\u0639\u0627\u0631: \u062a\u0645\u062a \u0625\u0632\u0627\u0644\u0629 \u0645\u0644\u0641 \u0627\u0644\u0648\u0633\u0627\u0626\u0637 \u0627\u0644\u0645\u062a\u0639\u062f\u062f\u0629.",
+        "en": "Notice: multimedia file been removed.",
         "es": "Aviso: archivo multimedia eliminado.",
         "fr": "Remarque: le fichier multim\u00e9dia a \u00e9t\u00e9 supprim\u00e9.",
         "it": "Avviso: il file multimediale \u00e8 stato rimosso."

--- a/templates/display.html
+++ b/templates/display.html
@@ -185,13 +185,15 @@
 	</div>  
 	{% elif vid.enable == 1 %}
 	<div class="col-xs-8">
-		<video id='vidd'
-			src="{{ url_for('static', filename='multimedia/'+vid.vname) }}"
-			height="600px" width="1300px" autoplay
-			{% if vid.controls == 1 %} controls {% endif %}
-			{% if vid.ar == 1 %} loop {% endif %}
-			{% if vid.mute == 1 %} muted {% endif %}
-		></video>
+		<center>
+			<video id='vidd' class='img-responsive'
+				src="{{ url_for('static', filename='multimedia/'+vid.vname) }}"
+				autoplay
+				{% if vid.controls == 1 %} controls {% endif %}
+				{% if vid.ar == 1 %} loop {% endif %}
+				{% if vid.mute == 1 %} muted {% endif %}
+			></video>
+		</center>
 	</div>
 	{% endif %}
 </div>

--- a/todo_now.md
+++ b/todo_now.md
@@ -8,7 +8,8 @@
 - [x] Always hit tasks with office id to fix possible random redirection (2020-02-02)
 - [x] ~~Arabic GUI fonts on Windows~~ (2020-02-09)
 > Only effects Windows 10 with high DPI
-
+- [x] Fix multimedia unused files always showing up as used (2020-02-17)
+- [x] Fix video none-responsive resolution (2020-02-17)
 
 ### To Add :
 
@@ -20,6 +21,7 @@
 - [x] Option to display ticket number beside name on `display` screen (2020-02-12)
 - [x] Put random ticket on-hold (2020-02-10)
 - [x] Add time-spent-waiting column in `tasks` and `offices` (2020-02-15)
+- [x] Add printed ticket font size scaling (2020-02-16)
 
 - [x] Multiple Touch screen support **based on offices** (2020-02-13)
 - [x] Multiple Display screen support **based on offices** (2020-02-13)


### PR DESCRIPTION
- Fix none-responsive video in display screen, resolves #49
- Fix unused multimedia files always showing up as been used
- Fix customization tables default values
- Fix video customization to nullify with `None` instead of `0`
- Add `mkv` video file format to supported video formats

<hr/>

**Demo fix none-responsive video resolution:**

![fix_video_resolution](https://user-images.githubusercontent.com/26286907/74670398-28e3b500-51ba-11ea-8371-dc93f5ed3837.gif)

