### PR TITLE
MarkupSafe breaking the build

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -49,7 +49,7 @@ jsmin==2.2.2
 lesscpy==0.13.0
 Mako==1.0.7
 Markdown==2.6.9
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 netifaces==0.10.6
 olefile==0.44


### PR DESCRIPTION
This PR bumps MarkupSafe package due to Failing build when trying to import Feature from setuptools which is mentioned here https://github.com/pallets/markupsafe/issues/116