### PR TITLE
Add `lp` printing option for unix-like. Resolves #125

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -649,9 +649,12 @@ class Settings(db.Model, Mixin):
     notifications = db.Column(db.Boolean, nullable=True)
     strict_pulling = db.Column(db.Boolean, nullable=True)
     visual_effects = db.Column(db.Boolean, nullable=True)
+    lp_printing = db.Column(db.Boolean, nullable=True)
 
-    def __init__(self, notifications=True, strict_pulling=True, visual_effects=True):
+    def __init__(self, notifications=True, strict_pulling=True, visual_effects=True,
+                 lp_printing=False):
         self.id = 0
         self.notifications = notifications
         self.strict_pulling = strict_pulling
         self.visual_effects = visual_effects
+        self.lp_printing = lp_printing

--- a/app/forms.py
+++ b/app/forms.py
@@ -552,7 +552,7 @@ class Printer_f(FlaskForm):
     scale = SelectField(coerce=int)
     submit = SubmitField('Set ticket')
 
-    def __init__(self, inspected_printers_from_view, defLang='en', *args, **kwargs):
+    def __init__(self, inspected_printers_from_view, lp_printing, defLang='en', *args, **kwargs):
         super(Printer_f, self).__init__(*args, **kwargs)
         self.kind.label = gtranslator.translate("Select type of ticket to use : ", 'en', [defLang])
         self.kind.choices = [
@@ -571,7 +571,7 @@ class Printer_f(FlaskForm):
 
         if inspected_printers_from_view:
             for printer in inspected_printers_from_view:
-                if name == 'nt':
+                if name == 'nt' or lp_printing:
                     printer_choices.append((f'{printer}', f'Printer Name: {printer}'))
                 else:
                     vendor, product = printer.get('vendor'), printer.get('product')

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ from flask_minify import minify
 from sqlalchemy.exc import OperationalError
 
 from app.middleware import db, login_manager, files, gtranslator, gTTs, migrate
-from app.printer import get_printers
+from app.printer import get_printers_usb
 from app.views.administrate import administrate
 from app.views.core import core
 from app.views.customize import cust_app
@@ -115,7 +115,7 @@ def bundle_app(config={}):
     if os.name != 'nt':
         # !!! it did not work creates no back-end available error !!!
         # !!! strange bug , do not remove !!!
-        if get_printers():
+        if get_printers_usb():
             pass
 
     @app.route('/language_switch/<language>')
@@ -198,6 +198,7 @@ def bundle_app(config={}):
         return dict(path=path, adme=admin_route, brp=Markup('<br>'), ar=ar, version=VERSION, str=str,
                     defLang=session.get('lang'), getattr=getattr, settings=Settings.get(), Serial=Serial,
                     checkId=lambda id, records: id in [i.id for i in records], offices=Office.query.all(),
-                    moment_wrapper=moment_wrapper, current_path=quote(request.path, safe=''))
+                    moment_wrapper=moment_wrapper, current_path=quote(request.path, safe=''),
+                    windows=os.name == 'nt', unix=os.name != 'nt')
 
     return app

--- a/gt_cached.json
+++ b/gt_cached.json
@@ -308,6 +308,13 @@
         "fr": "Permet \u00e0 l'administrateur, autoris\u00e9 par les op\u00e9rateurs admin de rechercher avec des param\u00e8tres donn\u00e9s du num\u00e9ro de ticket, du pr\u00e9fixe de ticket et / ou de la date du ticket pour atteindre le ticket sp\u00e9cifique destin\u00e9 \u00e0 \u00eatre recherch\u00e9 de mani\u00e8re dynamique et r\u00e9parable.",
         "it": "Consente all'amministratore, autorizzato dagli amministratori, di cercare con determinati parametri il numero del biglietto, il prefisso del biglietto e la data del biglietto per raggiungere lo specifico biglietto destinato alla ricerca in modo dinamico e risolvibile, che era ben inteso nel design."
     },
+    "Alternative printer driver": {
+        "ar": "\u0628\u0631\u0646\u0627\u0645\u062c \u062a\u0634\u063a\u064a\u0644 \u0627\u0644\u0637\u0627\u0628\u0639\u0629 \u0627\u0644\u0628\u062f\u064a\u0644",
+        "en": "Alternative printer driver",
+        "es": "controlador de impresora Alternativa",
+        "fr": "pilote d'imprimante alternatif",
+        "it": "driver di stampa alternativo"
+    },
     "Always show ticket number: ": {
         "ar": "\u062a\u0638\u0647\u0631 \u062f\u0627\u0626\u0645\u0627 \u0631\u0642\u0645 \u0627\u0644\u062a\u0630\u0643\u0631\u0629:",
         "en": "Always show ticket number:",

--- a/migrations/versions/9e5b998a4c7b_.py
+++ b/migrations/versions/9e5b998a4c7b_.py
@@ -1,0 +1,28 @@
+""" Add `lp_printing` flag setting.
+
+Revision ID: 9e5b998a4c7b
+Revises: b41c62db00a1
+Create Date: 2020-06-08 15:33:00.315047
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9e5b998a4c7b'
+down_revision = 'b41c62db00a1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    try:
+        op.add_column('settings', sa.Column('lp_printing', sa.Boolean(), nullable=True))
+    except Exception:
+        pass
+
+
+def downgrade():
+    with op.batch_alter_table('settings') as batch:
+        batch.drop_column('lp_printing')

--- a/templates/base.html
+++ b/templates/base.html
@@ -146,6 +146,15 @@
                                             {{ translate('Disable' if settings.notifications == True else 'Enable', 'en', [defLang]) }}
                                         </a>
                                     </li>
+                                    {% if unix %}
+                                    <li class="dropdown-header">( {{ translate('Alternative printer driver', 'en', [defLang]) }} )</li>
+                                    <li>
+                                        <a href="{{ url_for('core.settings', setting='lp_printing', togo=current_path) }}">
+                                            <span class="fa fa-print"></span>
+                                            {{ translate('Disable' if settings.lp_printing == True else 'Enable', 'en', [defLang]) }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
                                     {% endif %}
                                 </ul>
                             </li>

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,8 @@ from atexit import register
 from app.main import bundle_app
 from app.middleware import db
 from app.database import (User, Operators, Office, Task, Serial, Media, Touch_store,
-                          Display_store, Vid, Slides_c, Slides, Aliases, Printer)
+                          Display_store, Vid, Slides_c, Slides, Aliases, Printer,
+                          Settings)
 from app.utils import absolute_path
 from app.tasks import stop_tasks
 
@@ -31,11 +32,16 @@ TEST_PREFIX = 'Z'
 PREFIXES = [p for p in list(map(lambda i: chr(i).upper(), range(97, 123))) if p != TEST_PREFIX]
 
 MODULES = [Serial, User, Operators, Task, Office, Media, Slides]
-DEFAULT_MODULES = [Touch_store, Display_store, Vid, Slides_c, Aliases, Printer]
+DEFAULT_MODULES = [Touch_store, Display_store, Vid, Slides_c, Aliases, Printer, Settings]
 DB_NAME = 'testing.sqlite'
 DB_PATH = absolute_path(DB_NAME)
 TEST_REPEATS = 3
 ENTRY_NUMBER = 10
+
+
+def before_exit():
+    os.path.isfile(DB_PATH) and os.remove(DB_PATH)
+    os.path.isfile(absolute_path('errors.log')) and os.remove(absolute_path('errors.log'))
 
 
 @pytest.fixture
@@ -65,6 +71,7 @@ def c():
 
     os.close(db_fd)
     os.unlink(app.config['DATABASE'])
+    before_exit()
 
 
 def teardown_tables(modules):
@@ -180,11 +187,6 @@ def get_first_office_with_tickets(client):
                                    Serial.office_id == office.id)\
                            .first():
                 return office
-
-
-def before_exit():
-    os.path.isfile(DB_PATH) and os.remove(DB_PATH)
-    os.path.isfile(absolute_path('errors.log')) and os.remove(absolute_path('errors.log'))
 
 
 register(before_exit)


### PR DESCRIPTION
Adding a new flag setting to enable/disable using the standard `lp` command-line utilities for printing on Unix-like systems `Linux`, `MacOS` ...:

![lp_flag_setting](https://user-images.githubusercontent.com/26286907/84051339-aa549280-a9b7-11ea-9046-5f30cb17ccd6.jpg)


