### PR TITLE
Minor refactoring to add get_or_reject decorator:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 install:
   - pip install -r requirements/test.txt
 
-script: flake8 app/**/** tests/** && python -m pytest -W ignore -vv tests/* --cov=./app
+script: flake8 app/**/** tests/** && pytest -vv tests/* --cov=./app
 after_success:
   - coveralls

--- a/app/database.py
+++ b/app/database.py
@@ -155,7 +155,7 @@ class Task(db.Model, Mixin):
 
         db.session.commit()
 
-class Serial(db.Model, TicketsMixin):
+class Serial(db.Model, TicketsMixin, Mixin):
     __tablename__ = "serials"
     id = db.Column(db.Integer, primary_key=True)
     number = db.Column(db.Integer)
@@ -194,6 +194,10 @@ class Serial(db.Model, TicketsMixin):
     @property
     def puller_name(self):
         return User.get(self.pulledBy).name
+
+    @classmethod
+    def all_clean(cls):
+        return cls.query.filter(cls.number != 100)
 
     @classmethod
     def all_office_tickets(cls, office_id):

--- a/installer.sh
+++ b/installer.sh
@@ -75,9 +75,9 @@ then
     source installiation/bin/activate
     if [ -z "$2" ]
     then
-      python -m flake8 app/**/** tests/** && python -m pytest --count=2 -W ignore -vv tests/* --cov=./app
+      python -m flake8 app/**/** tests/** && python -m pytest --count=2 -vv tests/* --cov=./app
     else
-      python -m flake8 app/**/** tests/** && python -m pytest --count=$2 -W ignore -vv tests/* --cov=./app
+      python -m flake8 app/**/** tests/** && python -m pytest --count=$2 -vv tests/* --cov=./app
     fi
   else
     echo $error1

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -26,7 +26,7 @@ Flask-Minify==0.15
 Flask-Moment==0.9.0
 Flask-QRcode==1.0.1
 Flask-Script==2.0.5
-Flask-SQLAlchemy==2.2
+Flask-SQLAlchemy==2.4.3
 Flask-Uploads==0.2.1
 Flask-WhooshAlchemy==0.56
 Flask-WTF==0.14.2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -26,7 +26,7 @@ Flask-Minify==0.15
 Flask-Moment==0.9.0
 Flask-QRcode==1.0.1
 Flask-Script==2.0.5
-Flask-SQLAlchemy==2.2
+Flask-SQLAlchemy==2.4.3
 Flask-Uploads==0.2.1
 Flask-WhooshAlchemy==0.56
 Flask-WTF==0.14.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@
 pytest==5.3.2
 pytest-cov==2.8.1
 pytest-repeat==0.8.0
-pytest-warnings==0.3.0
 coverage==4.5.4
 python-coveralls==2.9.3
 flake8==3.7.9


### PR DESCRIPTION
- Add `get_or_reject` decorator
- Refactor views to use `get_or_reject`
- Bump `Flask-SQLAlchemy` to 2.4.3
- Remove `pytest-warnings` from tests