### PR TITLE
Add header and sub-header fields to printed tickets

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -471,14 +471,18 @@ class Serial(db.Model, TicketsMixin, Mixin):
                                        *common_arguments,
                                        language=ticket_settings.langu,
                                        windows=windows,
-                                       unix=not windows)
+                                       unix=not windows,
+                                       header=ticket_settings.header or '',
+                                       sub=ticket_settings.sub or '')
                 else:
                     printer = assign(ticket_settings.vendor, ticket_settings.product,
                                      ticket_settings.in_ep, ticket_settings.out_ep)
                     (printit_ar if ticket_settings.langu == 'ar' else printit)(printer,
                                                                                *common_arguments,
                                                                                lang=ticket_settings.langu,
-                                                                               scale=ticket_settings.scale)
+                                                                               scale=ticket_settings.scale,
+                                                                               site=ticket_settings.sub or '',
+                                                                               header=ticket_settings.header or '')
             except Exception as e:
                 exception = e
 
@@ -640,9 +644,11 @@ class Printer(db.Model, Mixin):
     value = db.Column(db.Integer)
     scale = db.Column(db.Integer, default=1)
     name = db.Column(db.String(100), nullable=True)
+    header = db.Column(db.String(50), nullable=True)
+    sub = db.Column(db.String(100), nullable=True)
 
     def __init__(self, vendor=0, product=0, in_ep=None, out_ep=None, active=False,
-                 langu='en', value=1, scale=1, name=None):
+                 langu='en', value=1, scale=1, name=None, header=None, sub=None):
         self.vendor = vendor
         self.product = product
         self.in_ep = in_ep
@@ -652,6 +658,8 @@ class Printer(db.Model, Mixin):
         self.scale = scale
         self.name = name
         self.langu = langu
+        self.header = header
+        self.sub = sub
 
 
 # 00 Configuration Tabels 00 #

--- a/app/forms/customize.py
+++ b/app/forms/customize.py
@@ -236,6 +236,8 @@ class TicketForm(LocalizedForm):
                            choices=[('00', 'No printers were found')])
     scale = SelectField('Select font scaling measurement for printed tickets :',
                         coerce=int)
+    header = StringField('Enter a text header : ')
+    sub = StringField('Enter a text sub-header : ')
     submit = SubmitField('Set ticket')
 
     def __init__(self, inspected_printers_from_view, lp_printing, *args, **kwargs):

--- a/app/printer.py
+++ b/app/printer.py
@@ -159,18 +159,18 @@ def get_translation(text, language):
 
 def printit(printer, ticket, office, tnumber,
             task, cticket, site='https://fqms.github.io', lang='en',
-            scale=1):
+            scale=1, header='FQM'):
     office_header = get_translation('\nOffice : ', lang)
     task_header = get_translation('\nTask : ', lang)
     cur_ticket_header = get_translation('\nCurrent ticket : ', lang)
     ahead_header = get_translation('\nTickets ahead : ', lang)
 
     printer.set(align='center', **get_font_height_width('logo', scale))
-    printer.text("FQM\n")
+    printer.text(f"{header}\n")
     printer.set(align='center', **get_font_height_width('regular', scale))
     printer.text(get_translation('Version ', lang) + VERSION)
     printer.set('center', 'a', 'u', **get_font_height_width('regular', scale))
-    printer.text("\n" + site + "\n")
+    printer.text(f"\n{site}\n")
     printer.set(align='center', **get_font_height_width('spacer', scale))
     printer.text("\n" + '-' * 15 + "\n")
     printer.set(align='center', **get_font_height_width('large', scale))
@@ -188,7 +188,8 @@ def printit(printer, ticket, office, tnumber,
 
 
 def print_ticket_cli(printer, ticket, office, tickets_ahead, task, current_ticket,
-                     host='localhost', language='en', scale=1, windows=False, unix=False):
+                     host='localhost', language='en', scale=1, windows=False, unix=False,
+                     header='', sub=''):
     '''Print a ticket through the Command-Line interface.
 
     Parameters
@@ -215,9 +216,14 @@ def print_ticket_cli(printer, ticket, office, tickets_ahead, task, current_ticke
         if printing on Windows, by default False
     unix : bool, optional
         if printing on Unix-like, by default False
+    header: str, optional
+        passes the ticket's text header
+    sub: str, optional
+        passes the ticket's sub text header
     '''
     ticket_content = printit(Dummy(), ticket, office, tickets_ahead, task,
-                             current_ticket, lang=language, scale=scale).output
+                             current_ticket, lang=language, scale=scale,
+                             header=header, site=sub).output
     file_path = path.join(getcwd(),
                           f'{uuid.uuid4()}'.replace('-', '') + '.txt')
 

--- a/app/views/customize.py
+++ b/app/views/customize.py
@@ -61,6 +61,9 @@ def ticket():
                       'danger')
                 return redirect(url_for('cust_app.ticket'))
 
+            printer.header = form.header.data
+            printer.sub = form.sub.data
+
             if windows or settings.lp_printing:
                 printer.name = printer_id
             else:
@@ -91,6 +94,8 @@ def ticket():
         form.langu.data = printer.langu
         form.value.data = printer.value
         form.scale.data = printer.scale
+        form.header.data = printer.header
+        form.sub.data = printer.sub
 
         if windows or settings.lp_printing:
             form.printers.data = printer.name or ''

--- a/migrations/versions/27a0b5682c34_.py
+++ b/migrations/versions/27a0b5682c34_.py
@@ -1,0 +1,29 @@
+"""Add header and sub-header fields to Printer
+
+Revision ID: 27a0b5682c34
+Revises: cf6ed76ef146
+Create Date: 2021-03-21 17:33:20.771426
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '27a0b5682c34'
+down_revision = 'cf6ed76ef146'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    try:
+        op.add_column('printers', sa.Column('header', sa.String(length=50), nullable=True))
+        op.add_column('printers', sa.Column('sub', sa.String(length=100), nullable=True))
+    except Exception:
+        pass
+
+
+def downgrade():
+    with op.batch_alter_table('printers') as b:
+        b.drop_column('sub')
+        b.drop_column('header')

--- a/templates/ticket.html
+++ b/templates/ticket.html
@@ -87,6 +87,12 @@ $(document).ready(function () {
           <div class="tohide hide">
             {{ render_field(form.scale, class="form-control") }}
           </div>
+          <div class="tohide hide">
+            {{ render_field(form.header, class="form-control") }}
+          </div>
+          <div class="tohide hide">
+            {{ render_field(form.sub, class="form-control") }}
+          </div>
 		    <center>
           <p class="pt-5"></p>
           <button class="btn btn-md btn-danger" type="submit">{{ translate('Apply', 'en', [defLang]) }}</button>

--- a/tests/views/core.py
+++ b/tests/views/core.py
@@ -251,7 +251,15 @@ def test_new_printed_ticket_arabic(c, monkeypatch):
     last_ticket = None
     mock_printer = MagicMock()
     image_path = os.path.join(os.getcwd(), 'dummy.jpg')
+    mock_pil = MagicMock()
+    mock_pil.truetype().getsize.return_value = (0, 0)
+    mock_pos = MagicMock()
+    mock_pos().output = b''
     monkeypatch.setattr(escpos.printer, 'Usb', mock_printer)
+    monkeypatch.setattr(app.printer, 'ImageDraw', mock_pil)
+    monkeypatch.setattr(app.printer, 'Image', mock_pil)
+    monkeypatch.setattr(app.printer, 'ImageFont', mock_pil)
+    monkeypatch.setattr(app.printer, 'Dummy', mock_pos)
 
     printer_settings = Printer.get()
     touch_screen_settings = Touch_store.get()
@@ -295,10 +303,18 @@ def test_new_printed_ticket_windows_arabic(c, monkeypatch):
     mock_os = MagicMock()
     mock_os.name = 'nt'
     mock_system = MagicMock()
+    mock_pil = MagicMock()
+    mock_pil.truetype().getsize.return_value = (0, 0)
+    mock_pos = MagicMock()
+    mock_pos().output = b''
     monkeypatch.setattr(app.database, 'os', mock_os)
     monkeypatch.setattr(app.printer, 'name', 'nt')
     monkeypatch.setattr(app.printer, 'uuid', mock_uuid)
     monkeypatch.setattr(app.printer, 'system', mock_system)
+    monkeypatch.setattr(app.printer, 'ImageDraw', mock_pil)
+    monkeypatch.setattr(app.printer, 'Image', mock_pil)
+    monkeypatch.setattr(app.printer, 'ImageFont', mock_pil)
+    monkeypatch.setattr(app.printer, 'Dummy', mock_pos)
 
     printer_settings = Printer.get()
     touch_screen_settings = Touch_store.get()
@@ -335,10 +351,18 @@ def test_new_printed_ticket_lp_arabic(c, monkeypatch):
     mock_os = MagicMock()
     mock_os.name = 'linux'
     mock_system = MagicMock()
+    mock_pil = MagicMock()
+    mock_pil.truetype().getsize.return_value = (0, 0)
+    mock_pos = MagicMock()
+    mock_pos().output = b''
     monkeypatch.setattr(app.views.core, 'os', mock_os)
     monkeypatch.setattr(app.printer, 'name', 'linux')
     monkeypatch.setattr(app.printer, 'uuid', mock_uuid)
     monkeypatch.setattr(app.printer, 'system', mock_system)
+    monkeypatch.setattr(app.printer, 'ImageDraw', mock_pil)
+    monkeypatch.setattr(app.printer, 'Image', mock_pil)
+    monkeypatch.setattr(app.printer, 'ImageFont', mock_pil)
+    monkeypatch.setattr(app.printer, 'Dummy', mock_pos)
 
     settings = Settings.get()
     printer_settings = Printer.get()

--- a/tests/views/core.py
+++ b/tests/views/core.py
@@ -82,6 +82,8 @@ def test_new_printed_ticket(c, monkeypatch):
     printer_settings.product = 3
     printer_settings.in_ep = 170
     printer_settings.out_ep = 170
+    header = printer_settings.header = 'testing header'
+    sub = printer_settings.sub = 'testing sub-header'
     db.session.commit()
     task = choice(Task.query.all())
     last_ticket = Serial.query.filter_by(task_id=task.id)\
@@ -105,6 +107,8 @@ def test_new_printed_ticket(c, monkeypatch):
     assert mock_printer().set.call_count == 7
     mock_printer().set.assert_called_with(align='left', height=1, width=1)
     mock_printer().cut.assert_called_once()
+    mock_printer().text.assert_any_call(f'{header}\n')
+    mock_printer().text.assert_any_call(f'\n{sub}\n')
     mock_printer().text.assert_any_call(f'\nOffice : {office.prefix}{office.name}\n')
     mock_printer().text.assert_any_call(f'\n{office.prefix}.{new_ticket.number}\n')
     mock_printer().text.assert_any_call(f'\nTickets ahead : {tickets.count()}\n')


### PR DESCRIPTION
Add header and sub-header fields to printed tickets, Resolves #193 

**Demo**:

![image](https://user-images.githubusercontent.com/26286907/111919152-87542480-8a99-11eb-8d5f-5f56eefd992a.png)
